### PR TITLE
Sets are now fetched based on last set's release date; some refactorings

### DIFF
--- a/add_set.py
+++ b/add_set.py
@@ -4,10 +4,6 @@ import requests
 import jsonpickle
 import time
 
-set_code = ""
-# json object storing final dump
-format_json = {}
-
 RESULT_FILE = "pauper-commander.json"
 # search for cards of rarity less than r and set of...
 SCRYFALL_SET_SEARCH_URL = "https://api.scryfall.com/cards/search?q=r%3Cr+set%3A{0}{1}"
@@ -99,27 +95,32 @@ def fetch_set_json(set_code, existing_commander_json):
 
 
 # ------------------------
-try:
-    set_code = sys.argv[1]
-except:
-    print("ERROR: Set code must be provided")
-    sys.exit()
+def main():
+    try:
+        set_code = sys.argv[1]
+    except:
+        print("ERROR: Set code must be provided")
+        sys.exit()
 
-# fetches existing list of cards
-existing_json = {}
-if os.path.exists(RESULT_FILE):
-    with open(RESULT_FILE) as card_file:
-        data = jsonpickle.decode(card_file.read())
-        for card in data:
-            existing_json[card.name] = card
+    # fetches existing list of cards
+    existing_json = {}
+    if os.path.exists(RESULT_FILE):
+        with open(RESULT_FILE) as card_file:
+            data = jsonpickle.decode(card_file.read())
+            for card in data:
+                existing_json[card.name] = card
 
-format_json = fetch_set_json(set_code, existing_json)
+    # json object storing final dump
+    format_json = fetch_set_json(set_code, existing_json)
 
-format_list = list(format_json.values()) + list(existing_json.values())
+    format_list = list(format_json.values()) + list(existing_json.values())
 
-format_list.sort(key=lambda x: x.name, reverse=False)
+    format_list.sort(key=lambda x: x.name, reverse=False)
 
-with open(RESULT_FILE, 'w') as output_file:
-    full_json_text = jsonpickle.encode(
-        value=format_list, indent=2, separators=(",", ": "))
-    output_file.write(full_json_text)
+    with open(RESULT_FILE, 'w') as output_file:
+        full_json_text = jsonpickle.encode(
+            value=format_list, indent=2, separators=(",", ": "))
+        output_file.write(full_json_text)
+
+
+main()

--- a/last_update.json
+++ b/last_update.json
@@ -1,4 +1,0 @@
-{
-  "last_update": "2021-10-15",
-  "last_setcode": "mic"
-}

--- a/last_update_metadata.json
+++ b/last_update_metadata.json
@@ -1,0 +1,3 @@
+{
+  "last_set_release_date": "2021-09-24"
+}


### PR DESCRIPTION
* Sets are now fetched based on the last set's release date and not based on its code and position in the sorted list to fix a problem when multiple sets have the same release date.
* Added some type annotations to update_json.py.
* Renamed a few things and added comments for clarity.
* Moved the main execution part of both files to a main() function to fix warnings about shadowing names.