### PR TITLE
Improved release date checks when fetching new sets.

### DIFF
--- a/add_set.py
+++ b/add_set.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from scryfall_fetcher import ScryfallFetcher
 from file_handler import FileHandler
@@ -10,6 +10,7 @@ from json_card import JsonCard
 SCRYFALL_SET_SEARCH_URL = "https://api.scryfall.com/cards/search?q=r%3Cr+set%3A{0}{1}"
 # looks like scryfall api responses don't include specific 'type', just 'type line' so we can parse each card to check or...only search good ones
 CARDTYPE_SEARCH_MODIFIER = "+in%3Apaper+(legal%3Avintage+OR+restricted%3Avintage+OR+banned%3Avintage)"
+
 
 # Fetches an entire set of cards from Scryfall given the search url, and returns them as an array
 def fetch_set(set_code: str) -> List:

--- a/file_handler.py
+++ b/file_handler.py
@@ -1,14 +1,15 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 import jsonpickle
 from typing import List, Dict, Optional
 
 from json_card import JsonCard
 
+
 class FileHandler:
     RESULT_FILE = "pauper_commander.json"
     UPDATE_METADATA_FILE = "last_update_metadata.json"
-    DATE_FORMAT = '%Y-%m-%d'
+    DATE_FORMAT = '%Y-%m-%d%z'
 
     @classmethod
     def get_existing_json(cls) -> Dict[str, JsonCard]:
@@ -24,12 +25,17 @@ class FileHandler:
 
     @classmethod
     def get_last_set_release_date(cls) -> Optional[datetime]:
-        """Gets the JSON file storing update metadata and returns the last set's release date.
+        """Gets the JSON file storing update metadata and returns the last set's release date as a time-zone-aware datetime.
         If the file doesn't exist, None is returned."""
         if os.path.exists(cls.UPDATE_METADATA_FILE):
             with open(cls.UPDATE_METADATA_FILE) as update_metadata_file:
                 data: Dict[str, str] = jsonpickle.decode(update_metadata_file.read())
-                last_set_release_date = datetime.strptime(data["last_set_release_date"], cls.DATE_FORMAT)
+                string_last_set_release_date = data["last_set_release_date"]
+                try:
+                    last_set_release_date = datetime.strptime(string_last_set_release_date, cls.DATE_FORMAT)
+                except ValueError:
+                    # Backwards compatibility: If there is no time zone info in the stored date, we assume it's in UTC 0.
+                    last_set_release_date = datetime.strptime(string_last_set_release_date, '%Y-%m-%d').replace(tzinfo=timezone.utc)
                 return last_set_release_date
         else:
             return None

--- a/last_update_metadata.json
+++ b/last_update_metadata.json
@@ -1,3 +1,3 @@
 {
-  "last_set_release_date": "2021-10-15"
+  "last_set_release_date": "2021-10-15-0800"
 }

--- a/legality.py
+++ b/legality.py
@@ -2,6 +2,7 @@ class PseudoEnum(type):
     def __contains__(cls, item):
         return item in cls.__dict__.values()
 
+
 class Legality(metaclass=PseudoEnum):
     BANNED = "Banned"
     LEGAL = "Legal"

--- a/scryfall_fetcher.py
+++ b/scryfall_fetcher.py
@@ -4,6 +4,7 @@ import jsonpickle
 import time
 from typing import List
 
+
 class ScryfallResponse:
     def __init__(self, data, was_successful=True, error_message=""):
         self.data: List = data
@@ -11,6 +12,7 @@ class ScryfallResponse:
         self.error_message: str = error_message
         if error_message is not None and error_message != "":
             self.was_successful = False
+
 
 class ScryfallFetcher:
     @staticmethod

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -4,6 +4,7 @@ from file_handler import FileHandler
 from legality import Legality
 from json_card import JsonCard
 
+
 class TestCard:
     def __init__(self, name, legality):
         self.name: str = name
@@ -115,11 +116,11 @@ def main():
     for card in TEST_CARDS:
         if card.name in existing_commander_json:
             if card.legality == existing_commander_json[card.name].legality:
-                total_tests_passed = total_tests_passed + 1
+                total_tests_passed += 1
             else:
                 print(f"TEST FAILED: Expected {card.name} to be {card.legality}, but it was {existing_commander_json[card.name].legality}.")
         elif card.legality == Legality.NOT_LEGAL:
-            total_tests_passed = total_tests_passed + 1
+            total_tests_passed += 1
         else:
             print(f"TEST FAILED: Expected {card.name} to be {card.legality}, but it was {Legality.NOT_LEGAL}.")
 

--- a/update_card.py
+++ b/update_card.py
@@ -5,6 +5,7 @@ from file_handler import FileHandler
 from legality import Legality
 from json_card import JsonCard
 
+
 def update_card_in_json(card_name: str, updated_legality: str, existing_format_json: Dict[str, JsonCard]):
     """Given a card name, its new legality, and a dict with legality info, updates the entry for that card in that dict."""
     if card_name in existing_format_json:

--- a/update_json.py
+++ b/update_json.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from typing import List, Dict, Optional
 
 from scryfall_fetcher import ScryfallFetcher
@@ -8,35 +8,37 @@ from add_set import update_json_with_set
 SCRYFALL_SETS_SEARCH_URL = "https://api.scryfall.com/sets?order%3Dreleased"
 ILLEGAL_SET_TYPES = ["token", "memorabilia", "funny"]
 
+
 class SetcodeFetchResult:
     def __init__(self, setcodes: List[str], last_set_release_date: datetime):
         self.setcodes = setcodes
         self.last_set_release_date = last_set_release_date
 
 
-def fetch_setcodes_as_recent_as(date: Optional[datetime]) -> SetcodeFetchResult:
+def fetch_setcodes_as_recent_as(earliest_allowed_date: Optional[datetime]) -> SetcodeFetchResult:
     """Given a datetime, returns a list of all codes of sets, which fulfill all conditions:
 
-    * were released yesterday or earlier;
+    * are already released when this check is performed
     * were released after or at the same day as the given datetime (if date is None, this condition is ignored);
     * aren't of an illegal type (such as un-sets)
     In addition to that, the release date of the newest returned set is returned as well.
     If no sets are returned, returns the given date instead."""
     print("Starting to fetch missing sets...", end=' ')
     setcodes_to_load: List[str] = []
-    today = datetime.now()
+    now = datetime.now(timezone.utc)  # We specify whatever time zone to make it time-zone-aware.
 
     scryfall_response = ScryfallFetcher.fetch_data(SCRYFALL_SETS_SEARCH_URL, raise_exceptions=True)
     total_sets: List[Dict[str, str]] = scryfall_response.data
 
-    # The first card_set is the most recent one.
+    _SCRYFALL_DATE_FORMAT = '%Y-%m-%d'
+    _SCRYFALL_RELEASE_DATE_TIMEZONE = timezone(timedelta(hours=-8))  # Scryfall uses UTC -8 for release dates.
+
     last_set_release_date: Optional[datetime] = None
     for card_set in total_sets:
-        release_date = datetime.strptime(card_set["released_at"], '%Y-%m-%d')
-        # We are using '%Y-%m-%d' instead of the DATE_FORMAT constant
-        # because how Scryfall stores dates doesn't have to match how we store dates.
-        if release_date < today \
-                and (date is None or date <= release_date) \
+        release_date = datetime.strptime(card_set["released_at"], _SCRYFALL_DATE_FORMAT)\
+            .replace(tzinfo=_SCRYFALL_RELEASE_DATE_TIMEZONE)  # We add info about time zone.
+        if release_date <= now \
+                and (earliest_allowed_date is None or earliest_allowed_date <= release_date) \
                 and card_set["set_type"] not in ILLEGAL_SET_TYPES:
             setcodes_to_load.append(card_set["code"])
             if last_set_release_date is None:
@@ -45,7 +47,7 @@ def fetch_setcodes_as_recent_as(date: Optional[datetime]) -> SetcodeFetchResult:
                 last_set_release_date = release_date
 
     if last_set_release_date is None:
-        last_set_release_date = date
+        last_set_release_date = earliest_allowed_date
 
     print(f"Done.\n"
           f"Fetched sets: {setcodes_to_load}")
@@ -57,7 +59,20 @@ def main():
     existing_json = FileHandler.get_existing_json()
     current_last_set_release_date = FileHandler.get_last_set_release_date()
 
-    setcode_fetch_result = fetch_setcodes_as_recent_as(current_last_set_release_date)
+    _DAYS_TO_LOOK_BEHIND = 1
+    setcode_fetch_result = fetch_setcodes_as_recent_as(current_last_set_release_date - timedelta(days=_DAYS_TO_LOOK_BEHIND))
+    # For simplicity we'll say N instead of _DAYS_TO_LOOK_BEHIND.
+    # We subtract N days as a safety measure to lower the odds of issues in case Scryfall is late with adding sets.
+    # Ideally instead of looking at the release date of sets we'd look at the date when sets are done adding to Scryfall,
+    # but as far as I know Scryfall's API doesn't have such info.
+
+    # A problem occurs when the following things happen in this order:
+    # 1. Set A is released.
+    # 2. Set B is released and added to Scryfall (in whatever order).
+    # 3. We run update_json, which adds set B and saves its release date.
+    # 4. Set A is added to Scryfall.
+    # 5. We run update_json again, so we fetch all sets released since set B, minus N days.
+    # 6. Now, if set A was released more than N days before set B, it won't be added to our JSON.
     codes_to_update = setcode_fetch_result.setcodes
     new_last_set_release_date = setcode_fetch_result.last_set_release_date
 


### PR DESCRIPTION
* Instead of not fetching sets which were released just today, we also fetch sets which were released a day before the newest set in our JSON. Both ways allow Scryfall to add sets one day after their release date with no risk of problems on our end, but the new way allows us to update sets' legality as soon as they are released.
* Time zones of release dates are now taken into account when fetching new sets.
* Applied minor code style changes.