### PR TITLE
Spruce up update_card script

### DIFF
--- a/pdh_json_updater/add_set.py
+++ b/pdh_json_updater/add_set.py
@@ -1,10 +1,10 @@
 import sys
 from typing import Dict, List
 
-from scryfall_fetcher import ScryfallFetcher
-from file_handler import FileHandler
-from legality import Legality
-from json_card import JsonCard
+from pdh_json_updater.scryfall_fetcher import ScryfallFetcher
+from pdh_json_updater.file_handler import FileHandler
+from pdh_json_updater.legality import Legality
+from pdh_json_updater.json_card import JsonCard
 
 # search for cards of rarity less than r and set of...
 SCRYFALL_SET_SEARCH_URL = "https://api.scryfall.com/cards/search?q=r%3Cr+set%3A{0}{1}"

--- a/pdh_json_updater/file_handler.py
+++ b/pdh_json_updater/file_handler.py
@@ -3,7 +3,7 @@ import os
 import jsonpickle
 from typing import List, Dict, Optional
 
-from json_card import JsonCard
+from pdh_json_updater.json_card import JsonCard
 
 
 class FileHandler:

--- a/pdh_json_updater/json_card.py
+++ b/pdh_json_updater/json_card.py
@@ -1,4 +1,4 @@
-from legality import Legality
+from pdh_json_updater.legality import Legality
 
 # transforms a scryfall card object into a json card object
 

--- a/pdh_json_updater/legality.py
+++ b/pdh_json_updater/legality.py
@@ -1,9 +1,7 @@
-class PseudoEnum(type):
-    def __contains__(cls, item):
-        return item in cls.__dict__.values()
+from enum import Enum
 
 
-class Legality(metaclass=PseudoEnum):
+class Legality(Enum):
     BANNED = "Banned"
     LEGAL = "Legal"
     LEGAL_AS_COMMANDER = "Legal As Commander"

--- a/pdh_json_updater/smoke_test.py
+++ b/pdh_json_updater/smoke_test.py
@@ -1,8 +1,8 @@
 from typing import Dict, List
 
-from file_handler import FileHandler
-from legality import Legality
-from json_card import JsonCard
+from pdh_json_updater.file_handler import FileHandler
+from pdh_json_updater.legality import Legality
+from pdh_json_updater.json_card import JsonCard
 
 
 class TestCard:

--- a/pdh_json_updater/update_card.py
+++ b/pdh_json_updater/update_card.py
@@ -1,10 +1,21 @@
 import sys
+import logging
+from argparse import ArgumentParser
+from argparse import Namespace
 from typing import Dict
 
-from file_handler import FileHandler
-from legality import Legality
-from json_card import JsonCard
+from pdh_json_updater.file_handler import FileHandler
+from pdh_json_updater.legality import Legality
+from pdh_json_updater.json_card import JsonCard
 
+LOGGER = logging.getLogger(__name__)
+
+def parse_update_card() -> Namespace:
+    """Parse cli options for the `update-card` script"""
+    parser = ArgumentParser(description="Update the legality entry for a card")
+    parser.add_argument("card_name", help="Oracle name of the card to be updated")
+    parser.add_argument("legality", help="Legality to assign to the given card", choices=[leg.name for leg in Legality])
+    return parser.parse_args()
 
 def update_card_in_json(card_name: str, updated_legality: str, existing_format_json: Dict[str, JsonCard]):
     """Given a card name, its new legality, and a dict with legality info, updates the entry for that card in that dict."""
@@ -12,24 +23,23 @@ def update_card_in_json(card_name: str, updated_legality: str, existing_format_j
         prev_card_ruling = existing_format_json[card_name]
         if updated_legality in Legality:
             prev_card_ruling.legality = updated_legality
-            print("Card object updated!")
+            LOGGER.info("Card object updated!")
         else:
-            print("ERROR: illegal rarity provided")
+            LOGGER.warning("ERROR: illegal rarity provided")
     else:
-        print(f"ERROR: {card_name} not found in existing commander json.")
+        LOGGER.warning(f"ERROR: {card_name} not found in existing commander json.")
 
 
 def main():
-    if len(sys.argv) != 3:  # The script itself is the first argument.
-        print(f"ERROR: Incorrect arguments.\n"
-              f"Correct usage: {sys.argv[0]} <card_name> <legality>\n"
-              f"Example: {sys.argv[0]} \"Snapcaster Mage\" \"Not Legal\"")
-        return
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
 
-    card_name = sys.argv[1]
-    updated_legality = sys.argv[2]
+    update_card_args = parse_update_card()
     format_json = FileHandler.get_existing_json()
-    update_card_in_json(card_name, updated_legality, format_json)
+    update_card_in_json(update_card_args.card_name, update_card_args.legality, format_json)
     FileHandler.save_format_json_to_file(format_json)
 
 

--- a/pdh_json_updater/update_json.py
+++ b/pdh_json_updater/update_json.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timezone, timedelta
 from typing import List, Dict, Optional
 
-from scryfall_fetcher import ScryfallFetcher
-from file_handler import FileHandler
-from add_set import update_json_with_set
+from pdh_json_updater.scryfall_fetcher import ScryfallFetcher
+from pdh_json_updater.file_handler import FileHandler
+from pdh_json_updater.add_set import update_json_with_set
 
 SCRYFALL_SETS_SEARCH_URL = "https://api.scryfall.com/sets?order%3Dreleased"
 ILLEGAL_SET_TYPES = ["token", "memorabilia", "funny"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Python scripts for updating the JSON file of all legal cards in the MTG PDH format"
 authors = ["Chev Eldrid"]
 
+[tool.poetry.scripts]
+update-card = "pdh_json_updater.update_card:main"
+
 [tool.poetry.dependencies]
 python = "^3.6"
 requests = "^2.27.1"


### PR DESCRIPTION
Adds `update-card` as a CLI-executable script

```
(pdh-json-updater-BKg2P6Ae-py3.9) [oreid@inferno pdh-json-updater]$ update-card -h
usage: update-card [-h] card_name {BANNED,LEGAL,LEGAL_AS_COMMANDER,NOT_LEGAL}

Update the legality entry for a card

positional arguments:
  card_name             Oracle name of the card to be updated
  {BANNED,LEGAL,LEGAL_AS_COMMANDER,NOT_LEGAL}
                        Legality to assign to the given card

optional arguments:
  -h, --help            show this help message and exit
```