### PR TITLE
Add weekly database update automation workflow

### DIFF
--- a/.github/workflows/weekly_update.yaml
+++ b/.github/workflows/weekly_update.yaml
@@ -1,0 +1,47 @@
+name: Run Weekly Database Update Automation
+
+on:
+  schedule:
+    cron: '0 9 * * 5'  # 9am (UTC) every Friday
+
+jobs:
+  run-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v2
+      - name: Setup minimum python version compatible with project
+        uses: actions/setup-python@v2
+        with:  # 3.6.15 is available on ubuntu-latest by default, cuts down on run time
+          python-version: 3.6.15  
+      - name: Load cached pypoetry installation and virtualenvs
+        uses: actions/cache@v2
+        with:
+          path: ~/.local
+          key: local-pypoetry
+      - name: Install pypoetry
+        uses: snok/install-poetry@v1.3.0
+        with:
+          version: 1.1.13
+          virtualenvs-path: ~/.local/opt/virtualenvs
+      - name: Install/update project dependencies
+        run: poetry install --no-interaction
+      - name: Attempt database update
+        run: poetry run python pdh_json_updater/update_json.py
+      - name: Check if database update occurred
+        id: check-update
+        run: echo "::set-output name=was-updated::$(git diff --quiet pauper_commander.json; echo $?)"
+      - name: Get current date
+        id: get-date
+        if: steps.check-update.outputs.was-updated == '1'
+        run: echo "::set-output name=current-date::$(date +%Y-%m-%d)"
+      - name: Submit pull request for database updates
+        if: steps.check-update.outputs.was-updated == '1'
+        uses: peter-evans/create-pull-request@v3
+        with:
+          add-paths: pauper_commander.json, last_update_metadata.json
+          branch: database-update/${{ steps.get-date.outputs.current-date }}
+          commit-message: Database update ${{ steps.get-date.outputs.current-date }}
+          title: Database update ${{ steps.get-date.outputs.current-date }}
+          reviewers: oakreid, chevEldrid
+


### PR DESCRIPTION
If the workflow does not update the database, the result will look like [this](https://github.com/chevEldrid/pdh-json-updater/runs/6050495289?check_suite_focus=true) and no pull request will be created

If the workflow updates the database, the result will look like [this](https://github.com/chevEldrid/pdh-json-updater/runs/6050485058?check_suite_focus=true) and a pull request will be submitted with the updates. The PR will resemble [this](https://github.com/chevEldrid/pdh-json-updater/pull/21) minus the extraneous development commits and the fact that its not being submitted to the master branch.

This automation will run once a week, let me know if you think I should change what time/day it runs.