### PR TITLE
Fix cron syntax for weekly update action

### DIFF
--- a/.github/workflows/weekly_update.yaml
+++ b/.github/workflows/weekly_update.yaml
@@ -2,7 +2,7 @@ name: Run Weekly Database Update Automation
 
 on:
   schedule:
-    cron: '0 9 * * 5'  # 9am (UTC) every Friday
+    - cron: '0 9 * * 5'  # 9am (UTC) every Friday
 
 jobs:
   run-update:


### PR DESCRIPTION
The `schedule` workflow key is supposed to take a list of `cron` maps, forgot the list part

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule