### PR TITLE
Fix Legality JSON serialization

### DIFF
--- a/pdh_json_updater/add_set.py
+++ b/pdh_json_updater/add_set.py
@@ -40,16 +40,16 @@ def update_json_with_set(set_code: str, existing_commander_json: Dict[str, JsonC
         json_card = JsonCard(card)
         card_name = json_card.name
 
-        if json_card.legality != Legality.NOT_LEGAL:
+        if json_card.legality != Legality.NOT_LEGAL.value:
             # if this is first printing, add to list. If this is a reprint, requires a little extra checking
             # if card["reprint"]: <- much cleaner, but only works if sets added chronologically since first printing, reprint = false
             if card_name in existing_commander_json:
                 prev_card_ruling = existing_commander_json[card_name]
                 if (
-                    prev_card_ruling.legality == Legality.LEGAL_AS_COMMANDER
-                    and json_card.legality == Legality.LEGAL
+                    prev_card_ruling.legality == Legality.LEGAL_AS_COMMANDER.value
+                    and json_card.legality == Legality.LEGAL.value
                 ):
-                    prev_card_ruling.legality = Legality.LEGAL
+                    prev_card_ruling.legality = Legality.LEGAL.value
             else:
                 existing_commander_json[card_name] = json_card
 

--- a/pdh_json_updater/json_card.py
+++ b/pdh_json_updater/json_card.py
@@ -32,21 +32,21 @@ class JsonCard:  # pylint: disable=too-few-public-methods
         front_card_face_typeline = scryfall_queried_card["type_line"].split("//")[0]
         # check for bannings
         if scryfall_queried_card["name"] in cls.PDH_BANLIST:
-            return Legality.BANNED
+            return Legality.BANNED.value
         # fixes rarity issues by allowing certain cards to be rendered "not legal"
         if scryfall_queried_card["name"] in cls.SOFT_BANLIST:
-            return Legality.NOT_LEGAL
+            return Legality.NOT_LEGAL.value
         # check illegal card types
         if front_card_face_typeline in cls.ILLEGAL_CARD_TYPES:
-            return Legality.NOT_LEGAL
+            return Legality.NOT_LEGAL.value
         # check rarity
         if scryfall_queried_card["rarity"] == "common":
-            return Legality.LEGAL
+            return Legality.LEGAL.value
         if (
             scryfall_queried_card["rarity"] == "uncommon"
             and "Creature" in front_card_face_typeline
         ):
             if "Land" in front_card_face_typeline:
-                return Legality.NOT_LEGAL
-            return Legality.LEGAL_AS_COMMANDER
-        return Legality.NOT_LEGAL
+                return Legality.NOT_LEGAL.value
+            return Legality.LEGAL_AS_COMMANDER.value
+        return Legality.NOT_LEGAL.value


### PR DESCRIPTION
After changing `Legality` to an actual Enum I neglected to update the places Legality was used to serialize just the value of the Enum rather than the entire object