### PR TITLE
Adds Legality Support for Uncommon Backgrounds

### DIFF
--- a/pdh_json_updater/json_card.py
+++ b/pdh_json_updater/json_card.py
@@ -42,6 +42,12 @@ class JsonCard:  # pylint: disable=too-few-public-methods
         # check rarity
         if scryfall_queried_card["rarity"] == "common":
             return Legality.LEGAL.value
+        # check for backgrounds, Legal Enchantment Commanders
+        if (
+            scryfall_queried_card["rarity"] == "uncommon"
+            and "Background" in front_card_face_typeline
+        ):
+            return Legality.LEGAL_AS_COMMANDER.value
         if (
             scryfall_queried_card["rarity"] == "uncommon"
             and "Creature" in front_card_face_typeline

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -78,6 +78,12 @@ TEST_CARDS: List[MockCard] = [
     MockCard(  # Illegal because it cannot be included in a deck
         name="Swords to Plowshares", legality=Legality.NOT_LEGAL
     ),
+    MockCard ( # Legal As Commander Uncommon Background
+        name="Acolyte of Bahamut", legality=Legality.LEGAL_AS_COMMANDER
+    ),
+    MockCard ( # Legal in 99 Common Background
+        name="Candlekeep Sage", legality=Legality.LEGAL
+    ),
 ]
 
 


### PR DESCRIPTION
This PR adds a Legal_as_commander check for Uncommon backgrounds
since they can be in the CZ. It also includes tests to confirm this
behavior, and the general legality of common backgrounds