### PR TITLE
Removes Alchemy sets from PDH Legal sets

### DIFF
--- a/pauper_commander.json
+++ b/pauper_commander.json
@@ -15121,12 +15121,6 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "0bbab99f-2ff6-4d48-b7c1-1ab0500c9422",
-    "name": "Demogorgon's Clutches",
-    "legality": "Legal"
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "08c6d2fd-d9ae-4f95-bb9d-7e16b1039814",
     "name": "Demolish",
     "legality": "Legal"
@@ -32019,7 +32013,7 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "43990801-ed4a-49ff-a96e-03faa302214f",
     "name": "Iron Golem",
-    "legality": "Legal"
+    "legality": "Legal As Commander"
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -73143,12 +73137,6 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "e0945337-1833-4545-a83f-fca673e7f0d0",
     "name": "You Come to the Gnoll Camp",
-    "legality": "Legal"
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "467c526a-02a7-405d-98de-c632ea83519b",
-    "name": "You Find Some Prisoners",
     "legality": "Legal"
   },
   {

--- a/pdh_json_updater/update_json.py
+++ b/pdh_json_updater/update_json.py
@@ -7,7 +7,7 @@ from pdh_json_updater.file_handler import FileHandler
 from pdh_json_updater.add_set import update_json_with_set
 
 SCRYFALL_SETS_SEARCH_URL = "https://api.scryfall.com/sets?order%3Dreleased"
-ILLEGAL_SET_TYPES = ["token", "memorabilia", "funny"]
+ILLEGAL_SET_TYPES = ["alchemy", "token", "memorabilia", "funny"]
 
 
 class SetcodeFetchResult:  # pylint: disable=too-few-public-methods
@@ -100,7 +100,9 @@ def main():
     for code in codes_to_update:
         update_json_with_set(code, existing_json)
 
-    FileHandler.save_format_json_to_file(existing_json, new_last_set_release_date)
+    FileHandler.save_format_json_to_file(
+        existing_json, new_last_set_release_date
+    )
 
 
 main()


### PR DESCRIPTION
Originally, we were considering Arena downshifts for PDH but since Arena
is pretty lax with rarities, we are removing Arena rarities from consideration.

While there will be edge cases in future, for now we can add the alchemy
set type to the list of illegal set types.