### PR TITLE
Updates Legalities for Eternal cards in Unsets

### DIFF
--- a/pdh_json_updater/json_card.py
+++ b/pdh_json_updater/json_card.py
@@ -14,7 +14,7 @@ class JsonCard:  # pylint: disable=too-few-public-methods
     ]
     # Cards "banned" as a workaround, e.g. due to incorrect rarities in Scryfall
     SOFT_BANLIST = ["Spatial Contortion", "Circle of Flame", "Swords to Plowshares"]
-    ILLEGAL_CARD_TYPES = ["Conspiracy"]
+    ILLEGAL_CARD_TYPES = ["Conspiracy", "Attraction"]
 
     def __init__(self, scryfall_queried_card):
         self.scryfallOracleId: str = (  # pylint: disable=invalid-name

--- a/pdh_json_updater/update_json.py
+++ b/pdh_json_updater/update_json.py
@@ -7,7 +7,7 @@ from pdh_json_updater.file_handler import FileHandler
 from pdh_json_updater.add_set import update_json_with_set
 
 SCRYFALL_SETS_SEARCH_URL = "https://api.scryfall.com/sets?order%3Dreleased"
-ILLEGAL_SET_TYPES = ["alchemy", "token", "memorabilia", "funny"]
+ILLEGAL_SET_TYPES = ["alchemy", "token", "memorabilia"]
 
 
 class SetcodeFetchResult:  # pylint: disable=too-few-public-methods
@@ -25,7 +25,7 @@ def fetch_setcodes_as_recent_as(
 
     * are already released when this check is performed
     * were released after or at the same day as the given datetime (if date is None, this condition is ignored);
-    * aren't of an illegal type (such as un-sets)
+    * aren't of an illegal type (such as alchemy sets)
     In addition to that, the release date of the newest returned set is returned as well.
     If no sets are returned, returns the given date instead."""
     print("Starting to fetch missing sets...", end=" ")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -84,6 +84,21 @@ TEST_CARDS: List[MockCard] = [
     MockCard ( # Legal in 99 Common Background
         name="Candlekeep Sage", legality=Legality.LEGAL
     ),
+    MockCard( # Legal As Commander from Unset
+        name="Ambassador Blorpityblorpboop", legality=Legality.LEGAL_AS_COMMANDER
+    ),
+    MockCard( # Illegal Commander from Unset
+        name="Juggletron", legality=Legality.NOT_LEGAL
+    ),
+    MockCard( # Legal in 99 from Unset
+        name="Croakid Amphibonaut", legality=Legality.LEGAL
+    ),
+    MockCard( # Illegal in 99 from Unset
+        name="Bar Entry", legality=Legality.NOT_LEGAL
+    ),
+    MockCard( # Illegal card type
+        name="Clown Extruder", legality=Legality.NOT_LEGAL
+    ),
 ]
 
 


### PR DESCRIPTION
Since "funny" sets can now have eternal legal cards, we need to update how we filter what sets  to check and how to check each cards of those sets