### PR TITLE
Updates after switch to isPauperCommander

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 This repo is for designing a script capable of automatically updating the format legality list for PDH using Scryfall's api
 
-
 To set up a virtual environment for development, first [install pypoetry onto your machine](https://python-poetry.org/docs/#installation).
 From there, you can [install your project dependencies](https://python-poetry.org/docs/basic-usage/#installing-dependencies) and
 [run any scripts in the library](https://python-poetry.org/docs/basic-usage/#using-poetry-run) within the virtualenv. You can also
 [build the contents of the repo into a python .whl](https://python-poetry.org/docs/cli#build) which can then be installed anywhere via `pip`
 
-
 ### Manual Override
+
 Sometimes, the robots fail us and we have to take PDH into our own hands. Quick Commander_json manual update Guide.
 
-1) Make sure [Poetry](https://python-poetry.org/docs/) is installed on your local machine, this is necessary to run the scripts
-2) run ```poetry install```, if you're on mac/windows you'll need ```poetry install --no-dev``` since dev dependencies aren't supported
-3) run ```poetry run python pdh_json_updater/update_json.py``` from top of the repo, this is the main script that triggers the updates to pauper_commander.json
+1. Make sure [Poetry](https://python-poetry.org/docs/) is installed on your local machine, this is necessary to run the scripts
+2. run `poetry install`, if you're on mac/windows you'll need `poetry install --no-dev` since dev dependencies aren't supported
+3. run `poetry run python pdh_json_updater/update_json.py` from top of the repo, this is the main script that triggers the updates to pauper_commander.json

--- a/full_run_notes.md
+++ b/full_run_notes.md
@@ -1,0 +1,10 @@
+Certain cards still fall between the cracks in the existing system. After a full re-run make sure to:
+
+- Blightbelly rat should be legal, isPauperCommander
+- Snowhorn Rider should be legal
+- Mardu Hateblade should be legal
+
+These could be caused by:
+
+- ONE had weird multi-rarity printings in the same set
+- KTK has a KTKy that might be mucking up specific printings

--- a/last_update_metadata.json
+++ b/last_update_metadata.json
@@ -1,3 +1,3 @@
 {
-  "last_set_release_date": "2024-11-15-0800"
+  "last_set_release_date": "2024-11-08-0800"
 }

--- a/pauper_commander.json
+++ b/pauper_commander.json
@@ -2458,6 +2458,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "481c3bfe-2293-447d-aa03-3ea6ed9321aa",
+    "name": "Ancestral Hot Dog Minotaur",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "13a9b9fd-20fa-4734-9d95-3ab41ab9c7a0",
     "name": "Ancestral Katana",
     "legality": "Legal",
@@ -8362,7 +8369,7 @@
     "scryfallOracleId": "b0102259-7a2c-470e-b04b-4a1f615d057c",
     "name": "Blightbelly Rat",
     "legality": "Legal",
-    "isPauperCommander": false
+    "isPauperCommander": true
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -12678,6 +12685,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "7e06b7b4-22c1-4e5b-81ee-54ab5ac756eb",
+    "name": "Carnival Elephant Meteor",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "b3360259-19df-43c6-95a9-e76770f2fb77",
     "name": "Carnivorous Canopy",
     "legality": "Legal",
@@ -16017,13 +16031,6 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "0895c9b7-ae7d-4bb3-af17-3b75deb50a25",
-    "name": "Command Tower // Command Tower",
-    "legality": "Legal",
-    "isPauperCommander": false
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "1dc816b5-8918-4a0c-bb10-74abe579a98c",
     "name": "Command the Storm",
     "legality": "Legal",
@@ -16577,6 +16584,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "67624a72-aa18-4b0c-a2cb-77e56499944a",
+    "name": "Contortionist Otter Storm",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "be9bee08-ac04-42bc-93be-5a77482a7690",
     "name": "Contortionist Troupe",
     "legality": "Not Legal",
@@ -16644,6 +16658,13 @@
     "name": "Convulsing Licid",
     "legality": "Not Legal",
     "isPauperCommander": true
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "ba2bb276-b7ef-46ec-9618-2cf4d60c70a6",
+    "name": "Cool Fluffy Loxodon",
+    "legality": "Legal",
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -18572,6 +18593,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "535fd365-19f4-4861-8f86-d814650355e9",
+    "name": "Cursed Firebreathing Yogurt",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "96e244ef-21b9-4795-a881-c3db23b60cc9",
     "name": "Cursed Flesh",
     "legality": "Legal",
@@ -20077,13 +20105,6 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "26e555f1-e0ed-4b84-8783-1c0c968f462d",
-    "name": "Deathcap Cultivator",
-    "legality": "Not Legal",
-    "isPauperCommander": true
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "6c4247d0-6dc8-4139-bbf5-c83dfdc7be1f",
     "name": "Deathcap Marionette",
     "legality": "Legal",
@@ -20361,6 +20382,13 @@
     "name": "Deep-Cavern Bat",
     "legality": "Not Legal",
     "isPauperCommander": true
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "43f5ce56-6ad1-4a42-b1d7-26f1c7933693",
+    "name": "Deep-Fried Plague Myr",
+    "legality": "Legal",
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -20807,6 +20835,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "2172b724-9004-488e-88d3-a5fc48c50e41",
     "name": "Demonic Torment",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "13d9822f-0398-4915-818b-b9fbaf63b93c",
+    "name": "Demonic Tourist Laser",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -24942,6 +24977,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "6614c21f-080e-441c-9ebb-c7369c1f52e1",
+    "name": "Eldrazi Guacamole Tightrope",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "25a73cfc-a40d-47ea-a7b1-61c7b62a9e6c",
     "name": "Eldrazi Ravager",
     "legality": "Not Legal",
@@ -25042,6 +25084,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "f9e668f9-21af-4fd8-9a37-6505ab2234e3",
     "name": "Elemental Summoning",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "5829ac8e-bd1c-4065-b30a-5307ab11ae79",
+    "name": "Elemental Time Flamingo",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -26699,6 +26748,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "60a69ddc-3289-4786-944d-27a82c5f0dc8",
+    "name": "Eternal Acrobat Toast",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "324a30cc-bddd-463c-9f28-c94c93a26780",
     "name": "Eternal Skylord",
     "legality": "Not Legal",
@@ -28040,6 +28096,13 @@
     "name": "Falthis, Shadowcat Familiar",
     "legality": "Not Legal",
     "isPauperCommander": true
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "41c0e1f1-8ebe-4cd2-96fe-e4bb625fe6ee",
+    "name": "Familiar Beeble Mascot",
+    "legality": "Legal",
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -31249,13 +31312,6 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "b34bb2dc-c1af-4d77-b0b3-a0fb342a5fc6",
-    "name": "Forest // Forest",
-    "legality": "Legal",
-    "isPauperCommander": false
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "0994d596-0b15-4156-8e94-5b566dcad6cd",
     "name": "Forest Bear",
     "legality": "Legal",
@@ -33139,10 +33195,10 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "64720167-b88b-47f7-bfc1-d5e005c9fd68",
-    "name": "Geier Reach Bandit // Vildin-Pack Alpha",
-    "legality": "Not Legal",
-    "isPauperCommander": true
+    "scryfallOracleId": "c0a448ee-e5f9-4e57-85b0-f6d401018170",
+    "name": "Geek Lotus Warrior",
+    "legality": "Legal",
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -33876,6 +33932,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "abfe31f1-7c6d-4a7a-9f44-7f3e4166d9f1",
     "name": "Giant Ladybug",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "26f6170a-34dc-41c8-b3b1-20377f131e6e",
+    "name": "Giant Mana Cake",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -35432,6 +35495,13 @@
     "name": "Goblin Commando",
     "legality": "Legal",
     "isPauperCommander": true
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "7cad08c1-4bd9-4d9f-85d2-fb3ab718fbb8",
+    "name": "Goblin Coward Parade",
+    "legality": "Legal",
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -38881,6 +38951,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "240a349a-79f8-4e11-9a05-a78148e70a62",
     "name": "Hapless Researcher",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "c3e5d355-fbfb-4489-aeea-8b0ea5de6fcd",
+    "name": "Happy Dead Squirrel",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -44104,7 +44181,7 @@
     "scryfallOracleId": "964e20e2-2947-4d8a-a0a2-b8b5fde27ff8",
     "name": "Ironclad Slayer",
     "legality": "Legal",
-    "isPauperCommander": true
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -44229,13 +44306,6 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "b2c6aa39-2d2a-459c-a555-fb48ba993373",
     "name": "Island",
-    "legality": "Legal",
-    "isPauperCommander": false
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "b2c6aa39-2d2a-459c-a555-fb48ba993373",
-    "name": "Island // Island",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -44824,6 +44894,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "f87df7d4-99e2-4340-9d0a-b96c397555db",
     "name": "Jetmir's Fixer",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "fe37c718-b3fb-4e95-a547-dd741b70421c",
+    "name": "Jetpack Death Seltzer",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -50898,13 +50975,6 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "303f91ae-1acb-4250-a4a5-71207c228dcc",
-    "name": "Lupine Prototype",
-    "legality": "Not Legal",
-    "isPauperCommander": true
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "771be8ad-5ab5-40b1-ad9b-e5e834949d32",
     "name": "Lurching Rotbeast",
     "legality": "Legal",
@@ -52084,6 +52154,13 @@
     "scryfallOracleId": "352844c5-2160-4787-97f1-9cd0fed060eb",
     "name": "Mardu Blazebringer",
     "legality": "Not Legal",
+    "isPauperCommander": true
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "acff2573-cf8a-4aee-96a3-28721a4128f6",
+    "name": "Mardu Hateblade",
+    "legality": "Legal",
     "isPauperCommander": true
   },
   {
@@ -53666,7 +53743,7 @@
     "scryfallOracleId": "1c29ae09-cc93-4a2a-b432-3c78ae01c1ed",
     "name": "Midnight Scavengers",
     "legality": "Legal",
-    "isPauperCommander": true
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -54752,6 +54829,13 @@
     "name": "Mistway Spy",
     "legality": "Not Legal",
     "isPauperCommander": true
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "658252ed-7f52-4a31-834b-c39cee1d5e00",
+    "name": "Misunderstood Trapeze Elf",
+    "legality": "Legal",
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -55854,13 +55938,6 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "a3fb7228-e76b-4e96-a40e-20b5fed75685",
-    "name": "Mountain // Mountain",
-    "legality": "Legal",
-    "isPauperCommander": false
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "e3638c54-e494-47d2-b614-94c9d9add85a",
     "name": "Mountain Bandit",
     "legality": "Legal",
@@ -56477,6 +56554,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "c490157a-cff5-417b-8f83-15f84398e34f",
+    "name": "Mystic Doom Sandwich",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "cf3b79cc-ce97-48e9-a578-625e323d1b62",
     "name": "Mystic Enforcer",
     "legality": "Not Legal",
@@ -56815,6 +56899,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "c96803dc-b69b-4fc3-a39b-1aad6d800e86",
     "name": "Narrow Escape",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "366e0a62-ff95-48d1-bc63-7995a393bc34",
+    "name": "Narrow-Minded Baloney Fireworks",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -57744,6 +57835,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "1436370f-baf0-4659-804e-90aad871b05b",
+    "name": "Night Brushwagg Ringmaster",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "4d2abfe1-f5f8-4ed5-915d-bfe98c6321ee",
     "name": "Night Clubber",
     "legality": "Not Legal",
@@ -58495,6 +58593,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "f93dbe17-71d1-4542-96ff-81ac6da9513f",
     "name": "Notion Rain",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "06f8efdd-4e8e-4524-859b-71f2f1732ad5",
+    "name": "Notorious Sliver War",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -62532,6 +62637,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "dde09abb-e3d3-4c76-b7e8-812949dd67f3",
+    "name": "Phyrexian Midway Bamboozle",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "be04f54f-59fa-4f0a-b8b5-790d568932b6",
     "name": "Phyrexian Missionary",
     "legality": "Not Legal",
@@ -63246,13 +63358,6 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "bc71ebf6-2056-41f7-be35-b2e5c34afa99",
-    "name": "Plains // Plains",
-    "legality": "Legal",
-    "isPauperCommander": false
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "9ae30bd5-b638-4647-b59d-ffe08e77c182",
     "name": "Planar Ally",
     "legality": "Legal",
@@ -63369,6 +63474,13 @@
     "name": "Plaxmanta",
     "legality": "Not Legal",
     "isPauperCommander": true
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "065cdf8d-6874-4ab6-a08e-79bd88b245bd",
+    "name": "Playable Delusionary Hydra",
+    "legality": "Legal",
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -63809,7 +63921,7 @@
     "scryfallOracleId": "37c49483-bef6-47c6-9354-ead8560d48da",
     "name": "Pradesh Gypsies",
     "legality": "Banned",
-    "isPauperCommander": true
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -64137,6 +64249,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "d031d7d2-1e41-4201-9073-c4c1be182ba4",
     "name": "Primal Druid",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "a7a00246-54e7-4213-b95b-907ab9015e53",
+    "name": "Primal Elder Kitty",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -68324,7 +68443,7 @@
     "scryfallOracleId": "a83073a2-e63d-4105-8bad-9612e411fc85",
     "name": "Repentant Blacksmith",
     "legality": "Legal",
-    "isPauperCommander": true
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -72318,6 +72437,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "16663933-c8e2-4411-8eed-673c52fa3ecb",
+    "name": "Sassy Gremlin Blood",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "aa321138-b1a7-4b8e-a2ca-b9ce65704e92",
     "name": "Satyr Enchanter",
     "legality": "Not Legal",
@@ -73239,13 +73365,6 @@
     "name": "Scourge Servant",
     "legality": "Legal",
     "isPauperCommander": false
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "fd74d0f6-bbe5-47f6-af15-a127489ca7f3",
-    "name": "Scourge Wolf",
-    "legality": "Not Legal",
-    "isPauperCommander": true
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -74491,7 +74610,7 @@
     "scryfallOracleId": "8f36e058-e5fa-48f9-9996-09b77fc193b3",
     "name": "Self-Assembler",
     "legality": "Legal",
-    "isPauperCommander": false
+    "isPauperCommander": true
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -74645,7 +74764,7 @@
     "scryfallOracleId": "a37c9b13-dc45-4b55-a63d-5314abde7aab",
     "name": "Sentinel Spider",
     "legality": "Legal",
-    "isPauperCommander": true
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -78926,6 +79045,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "2d13d399-7198-4cab-b564-dfe0e09425a3",
+    "name": "Slimy Burrito Illusion",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "ccb1b532-92b8-4ebf-b3c2-fb5924b116f5",
     "name": "Slimy Dualleech",
     "legality": "Not Legal",
@@ -79528,6 +79654,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "3e5ac76b-08bd-4232-9290-49742b0ff603",
+    "name": "Snazzy Aether Homunculus",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "3eabd27c-bd65-479a-9743-e90e4273c016",
     "name": "Sneaking Guide",
     "legality": "Legal",
@@ -79628,6 +79761,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "749c2c8e-9588-4e83-b07f-3c37eb63338b",
     "name": "Snowfield Sinkhole",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "3d5a753b-ed2d-4646-ade3-5daeba2a7270",
+    "name": "Snowhorn Rider",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -79987,13 +80127,6 @@
     "name": "Somberwald Dryad",
     "legality": "Legal",
     "isPauperCommander": false
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "f249db15-09fa-4a1c-9461-9ae803c219b6",
-    "name": "Somberwald Sage",
-    "legality": "Not Legal",
-    "isPauperCommander": true
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -80650,6 +80783,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "2ec1860b-89cc-4529-8b8c-fb47f79f2b4b",
     "name": "Sower of Chaos",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "fd29fdbd-b4c5-4d23-9388-df0a798fbbba",
+    "name": "Space Fungus Snickerdoodle",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -81936,6 +82076,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "785e6563-51c4-4063-9ad9-0392954e135e",
+    "name": "Spooky Clown Mox",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "36d55084-4696-4d16-ab3a-b00f1456603f",
     "name": "Spore Cloud",
     "legality": "Legal",
@@ -82335,6 +82482,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "5bd19c93-4b1b-45d7-9764-1327fffe94ca",
+    "name": "Squid Fire Knight",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "aa6cdcc7-f5ea-47bf-9448-1c63e36b18d1",
     "name": "Squire",
     "legality": "Legal",
@@ -82367,6 +82521,13 @@
     "name": "Squirrel Squatters",
     "legality": "Not Legal",
     "isPauperCommander": true
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "d198b39d-2c5f-4150-8c54-a00d33d74a28",
+    "name": "Squishy Sphinx Ninja",
+    "legality": "Legal",
+    "isPauperCommander": false
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -83142,6 +83303,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "fa8ddc13-5108-4fe9-b3aa-dc28df476f7b",
     "name": "Sticky Fingers",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "3def54bf-2640-47de-84e8-7a9406df007e",
+    "name": "Sticky Kavu Daredevil",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -84180,13 +84348,6 @@
     "name": "Stromkirk Mentor",
     "legality": "Legal",
     "isPauperCommander": false
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "3bdd140b-1406-4d07-8f35-78f2ba92de64",
-    "name": "Stromkirk Occultist",
-    "legality": "Not Legal",
-    "isPauperCommander": true
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
@@ -85291,13 +85452,6 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "56719f6a-1a6c-4c0a-8d21-18f7d7350b68",
     "name": "Swamp",
-    "legality": "Legal",
-    "isPauperCommander": false
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "56719f6a-1a6c-4c0a-8d21-18f7d7350b68",
-    "name": "Swamp // Swamp",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -86825,13 +86979,6 @@
     "scryfallOracleId": "ff0086e0-706f-4474-9b5e-a1591235bf9b",
     "name": "Tempest Drake",
     "legality": "Not Legal",
-    "isPauperCommander": true
-  },
-  {
-    "py/object": "pdh_json_updater.json_card.JsonCard",
-    "scryfallOracleId": "272016e1-df1e-4376-9851-af8b1ecba2f4",
-    "name": "Tempest Efreet",
-    "legality": "Banned",
     "isPauperCommander": true
   },
   {
@@ -90007,6 +90154,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "7a1ff7f3-0b3e-47fe-9e89-522c04f53869",
+    "name": "Trained Blessed Mind",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "a939f01b-afce-4d92-a897-1a6dc3d788c6",
     "name": "Trained Caracal",
     "legality": "Legal",
@@ -90513,6 +90667,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "31136103-535a-4d11-819a-1cbd57ad48a4",
     "name": "Trenching Steed",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "eb980d94-2860-4fe5-85e0-2757985721f1",
+    "name": "Trendy Circus Pirate",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -91582,6 +91743,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "6ad4d181-21ce-47f3-9c00-2aa8c307e7fe",
+    "name": "Unassuming Gelatinous Serpent",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "1cf4e16b-2273-41c7-9bcd-0cdc78e12198",
     "name": "Unassuming Sage",
     "legality": "Legal",
@@ -92037,6 +92205,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "eb1c4f0a-b993-4aa1-8b13-1695b5f63653",
+    "name": "Unglued Pea-Brained Dinosaur",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "da1dd850-9118-42b9-8846-e6bd5042775c",
     "name": "Unhallowed Pact",
     "legality": "Legal",
@@ -92053,6 +92228,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "cb1ae4f2-4fec-4cac-8992-616af82e0ade",
     "name": "Unhinge",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "ea1fb0c3-d52c-4435-af2c-4b74f31189f7",
+    "name": "Unhinged Beast Hunt",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -92109,6 +92291,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "4492c329-174a-44aa-be4d-9f018173b9a7",
     "name": "Union of the Third Path",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "989346e5-3e76-40ce-8295-d267929d4fd5",
+    "name": "Unique Charmed Pants",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -92247,6 +92436,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "4413cb03-d6e9-4e6c-b5fe-9240ca0ebd13",
+    "name": "Unsanctioned Ancient Juggler",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "3e7879d5-62ea-4c9a-9fc0-659d70f3a8e1",
     "name": "Unscrupulous Agent",
     "legality": "Legal",
@@ -92291,6 +92487,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "060ae1bb-956a-4264-b405-a33151f31493",
     "name": "Unstable Obelisk",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "676de97a-299b-42ac-aa93-bb12dc9c4460",
+    "name": "Unstable Robot Dragon",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -92583,6 +92786,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "7abe9119-cc5d-4004-8a46-4a3153ead570",
+    "name": "Urza's Dark Cannonball",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "bf6ea878-044b-40a8-a21b-0191a948a69a",
     "name": "Urza's Engine",
     "legality": "Not Legal",
@@ -92830,6 +93040,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "a48d2be2-395a-4377-a2ad-51dbbc5b4e17",
     "name": "Vampire Champion",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "be19d5ef-15ed-422d-8799-63eabfdbaae3",
+    "name": "Vampire Champion Fury",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -97329,6 +97546,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "2c925531-63f8-4a6b-bfe0-bb8cd5d0d63d",
+    "name": "Weird Angel Flame",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "3af07cd3-36c3-4792-bc93-3ec82e1606bb",
     "name": "Weirded Vampire",
     "legality": "Legal",
@@ -97415,6 +97639,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "96cf3320-c730-4618-8768-28a179f4d9c0",
     "name": "Werebear",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "a72927dc-b633-4830-be39-40674ed74ef3",
+    "name": "Werewolf Lightning Mage",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -97954,6 +98185,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "35d3d96a-d303-4bf5-b972-f311331ec07a",
     "name": "Wild Nacatl",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "578c23d2-225f-4488-be7f-4abe38297bde",
+    "name": "Wild Ogre Bupkis",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -99415,6 +99653,13 @@
   },
   {
     "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "f7016cec-bb17-4f56-bf8e-3d8c83e6e41b",
+    "name": "Wrinkly Monkey Shenanigans",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "1ea7f839-e3b8-4aff-b850-c0a98b06ae14",
     "name": "Writ of Passage",
     "legality": "Legal",
@@ -99711,6 +99956,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "93514874-41e8-49e7-8935-d06e852dd1e3",
     "name": "Yavimaya Wurm",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "4c02ee30-8681-45ed-adb5-edf06409eee4",
+    "name": "Yawgmoth Merfolk Soul",
     "legality": "Legal",
     "isPauperCommander": false
   },
@@ -100397,6 +100649,13 @@
     "py/object": "pdh_json_updater.json_card.JsonCard",
     "scryfallOracleId": "baab3245-6616-4a4a-a168-3215a7878073",
     "name": "Zombie Cannibal",
+    "legality": "Legal",
+    "isPauperCommander": false
+  },
+  {
+    "py/object": "pdh_json_updater.json_card.JsonCard",
+    "scryfallOracleId": "786bdf20-b1f1-40f7-acd0-8dcb46da2bb0",
+    "name": "Zombie Cheese Magician",
     "legality": "Legal",
     "isPauperCommander": false
   },

--- a/pdh_json_updater/add_set.py
+++ b/pdh_json_updater/add_set.py
@@ -11,9 +11,8 @@ from pdh_json_updater.json_card import JsonCard
 # search for cards of rarity less than r and set of...
 SCRYFALL_SET_SEARCH_URL = "https://api.scryfall.com/cards/search?q=r%3Cr+set%3A{0}{1}"
 # looks like scryfall api responses don't include specific 'type', just 'type line' so we can parse each card to check or...only search good ones
-CARDTYPE_SEARCH_MODIFIER = (
-    "+in%3Apaper+(legal%3Avintage+OR+restricted%3Avintage+OR+banned%3Avintage)"
-)
+# Adding stickers to the top level here so I don't have to add manually
+CARDTYPE_SEARCH_MODIFIER = "+in%3Apaper+(legal%3Avintage+OR+restricted%3Avintage+OR+banned%3Avintage+OR+t%3AStickers)"
 
 
 def fetch_set(set_code: str) -> List:
@@ -39,7 +38,7 @@ def update_json_with_set(set_code: str, existing_commander_json: Dict[str, JsonC
     # transforms each card in mtg_set and adds them to a "format_additions" to be merged with master list
     for card in mtg_set:
         json_card = JsonCard(card)
-        card_name = json_card.name
+        card_oracle_id = json_card.scryfallOracleId
 
         # if this is first printing, add to list. If this is a reprint, requires a little extra checking
         # if card["reprint"]: <- much cleaner, but only works if sets added chronologically since first printing, reprint = false
@@ -47,15 +46,15 @@ def update_json_with_set(set_code: str, existing_commander_json: Dict[str, JsonC
             json_card.legality != Legality.NOT_LEGAL.value
             or json_card.isPauperCommander
         ):
-            if card_name in existing_commander_json:
-                prev_card_ruling = existing_commander_json[card_name]
+            if card_oracle_id in existing_commander_json:
+                prev_card_ruling = existing_commander_json[card_oracle_id]
                 if json_card.legality == Legality.LEGAL.value:
                     prev_card_ruling.legality = Legality.LEGAL.value
                 # update pauper commander status
                 if json_card.isPauperCommander:
                     prev_card_ruling.isPauperCommander = True
             else:
-                existing_commander_json[card_name] = json_card
+                existing_commander_json[card_oracle_id] = json_card
 
 
 # ------------------------

--- a/pdh_json_updater/file_handler.py
+++ b/pdh_json_updater/file_handler.py
@@ -1,4 +1,5 @@
 """File handlers classes"""
+
 from datetime import datetime, timezone
 import os
 import jsonpickle
@@ -18,6 +19,19 @@ class FileHandler:
     def get_existing_json(cls) -> Dict[str, JsonCard]:
         """Gets the JSON file storing legality information about all cards and returns a Dict[str, JsonCard].
         If the file doesn't exist, an empty dict is returned."""
+        existing_json: Dict[str, JsonCard] = {}
+        if os.path.exists(cls.RESULT_FILE):
+            with open(cls.RESULT_FILE, encoding="utf-8") as card_file:
+                data: List[JsonCard] = jsonpickle.decode(card_file.read())
+                for card in data:
+                    existing_json[card.scryfallOracleId] = card
+        return existing_json
+
+    @classmethod
+    def get_existing_json_names(cls) -> Dict[str, JsonCard]:
+        """Gets the JSON file storing legality information about all cards and returns a Dict[str, JsonCard].
+        If the file doesn't exist, an empty dict is returned. This particular one sorts by name for test ease
+        """
         existing_json: Dict[str, JsonCard] = {}
         if os.path.exists(cls.RESULT_FILE):
             with open(cls.RESULT_FILE, encoding="utf-8") as card_file:

--- a/pdh_json_updater/json_card.py
+++ b/pdh_json_updater/json_card.py
@@ -77,6 +77,8 @@ class JsonCard:  # pylint: disable=too-few-public-methods
             front_card_face = scryfall_queried_card["card_faces"][0]
             front_card_face_typeline = front_card_face["type_line"]
         # check for backgrounds, Legal Enchantment Commanders
+        if scryfall_queried_card["name"] in cls.PDH_BANLIST:
+            return False
         if (
             scryfall_queried_card["rarity"] == "uncommon"
             and "Background" in front_card_face_typeline

--- a/pdh_json_updater/update_json.py
+++ b/pdh_json_updater/update_json.py
@@ -9,6 +9,8 @@ from pdh_json_updater.add_set import update_json_with_set
 
 SCRYFALL_SETS_SEARCH_URL = "https://api.scryfall.com/sets?order%3Dreleased"
 ILLEGAL_SET_TYPES = ["alchemy", "token", "memorabilia", "promo"]
+# sets to ignore, largely arena-only masters sets, and non-english releases
+ILLEGAL_SET_CODES = ["sir", "pio", "sis", "anb", "ren", "rin", "pwcs", "psal"]
 # types of sets that would have prerelease events and therefore release early
 PRERELEASE_SET_TYPES = ["core", "expansion", "masters", "funny"]
 
@@ -61,6 +63,7 @@ def fetch_setcodes_as_recent_as(
             release_date <= now
             and (earliest_allowed_date is None or earliest_allowed_date <= release_date)
             and card_set["set_type"] not in ILLEGAL_SET_TYPES
+            and card_set["code"] not in ILLEGAL_SET_CODES
         ):
             setcodes_to_load.append(card_set["code"])
             if last_set_release_date is None:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -127,18 +127,28 @@ TEST_CARDS: List[MockCard] = [
     MockCard(  # Illegal due to Arena-specific downshift
         name="Spiritual Guardian", legality=Legality.NOT_LEGAL
     ),
+    MockCard(  # Legal but keeps getting removed - check full_run_notes for details
+        name="Snowhorn Rider", legality=Legality.LEGAL
+    ),
+    MockCard(  # Legal as commander but ONE is weird, check full_run_notes for details
+        name="Blightbelly Rat", legality=Legality.LEGAL, isPauperCommander=True
+    ),
 ]
 
 
 def test_smoke():
     """Test basic database operations"""
-    existing_commander_json: Dict[str, JsonCard] = FileHandler.get_existing_json()
+    existing_commander_json: Dict[str, JsonCard] = FileHandler.get_existing_json_names()
     total_tests = len(TEST_CARDS)
     total_tests_passed = 0
 
     for card in TEST_CARDS:
         if card.name in existing_commander_json:
-            if card.legality.value == existing_commander_json[card.name].legality:
+            if (
+                card.legality.value == existing_commander_json[card.name].legality
+                and card.isPauperCommander
+                == existing_commander_json[card.name].isPauperCommander
+            ):
                 total_tests_passed += 1
             else:
                 print(


### PR DESCRIPTION
- Legalize stickers
- remove duplicates by switching match to oracleId as opposed to name
- remove culturally banned cards from being legal commanders
- add list of set codes to ignore in future runs
- add notes of edge case cards to add on full runs